### PR TITLE
Add wrapper macros for hex and CBOR

### DIFF
--- a/defmt-or-log/Cargo.toml
+++ b/defmt-or-log/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["embedded", "no-std"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-defmt = { version = "0.3.10", optional = true }
+defmt = { version = "1.0.0", optional = true }
 log = { version = "0.4.26", optional = true }
 defmt-or-log-macros = { version = "0.1.0", path = "../defmt-or-log-macros" }
 

--- a/defmt-or-log/src/lib.rs
+++ b/defmt-or-log/src/lib.rs
@@ -7,3 +7,5 @@ mod traits;
 pub use traits::*;
 
 pub use defmt_or_log_macros::*;
+
+pub mod wrappers;

--- a/defmt-or-log/src/wrappers.rs
+++ b/defmt-or-log/src/wrappers.rs
@@ -1,0 +1,67 @@
+//! Newtypes that implement styles of display that can not be expressed with a unified portable
+//! expression in both defmt and Rust string formatting.
+
+/// A newtype around byte slices produces hex output.
+///
+/// Its preferred output is `00 11 22 33`, but backends may also produce something like `[00, 11,
+/// 22, 33]` (eg. while that is cheaper on defmt).
+///
+/// Instead of writing some variation of `info!("Found bytes {:02x}", data)` in defmt (or
+/// `… {:02x?}", data`) for log), you can write `info!("Found bytes {}", Hex(&data))`.
+pub struct Hex<T: AsRef<[u8]>>(pub T);
+
+impl<T: AsRef<[u8]>> core::fmt::Display for Hex<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut first = true;
+        for byte in self.0.as_ref() {
+            if !first {
+                write!(f, " ")?;
+            }
+            write!(f, "{:02x}", byte)?;
+            first = false;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T: AsRef<[u8]>> defmt::Format for Hex<T> {
+    fn format(&self, f: defmt::Formatter) {
+        // If defmt ever gains a `:hexdump` or similar formatting, this can be upgraded.
+        ::defmt::write!(f, "{=[u8]:02x}", self.0.as_ref())
+    }
+}
+
+/// A newtype around byte slices used for that prefers interpreting the data as CBOR.
+///
+/// Its preferred output is CBOR Diagnostic Notation (EDN), but showing hex is also acceptable.
+///
+/// Instead of writing some variation of `info!("Found bytes {:cbor}", item)`, you can write
+/// `info!("Found bytes {}", Cbor(&item))`.
+///
+/// Note that using this wrapper is not necessary when using a
+/// [`cboritem::CborItem`](https://docs.rs/cboritem/latest/cboritem/struct.CborItem.html) as it
+/// already does something similar on its own.
+pub struct Cbor<T: AsRef<[u8]>>(pub T);
+
+impl<T: AsRef<[u8]>> core::fmt::Display for Cbor<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Hex(self.0.as_ref()).fmt(f)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T: AsRef<[u8]>> defmt::Format for Cbor<T> {
+    fn format(&self, f: defmt::Formatter) {
+        ::defmt::write!(f, "{=[u8]:cbor}", self.0.as_ref())
+    }
+}
+
+#[test]
+fn test_hex() {
+    extern crate alloc;
+    use alloc::format;
+    assert_eq!("", format!("{}", Hex([])));
+    assert_eq!("00", format!("{}", Hex([0x00])));
+    assert_eq!("00 01 02", format!("{}", Hex([0x00, 0x01, 0x02])));
+}


### PR DESCRIPTION
Some expressions don't work quite the same way on defmt and log: `{:02x}` formatting of defmt needs a `?` after it in log (which then doesn't work with defmt), and defmt's `:cbor` doesn't work with string formatting at all (so this provides at least a fallback).

I originally used those in [Ariel OS](https://github.com/ariel-os/ariel-os/), but given that there are other crates that need the same, this could be a good place.