### PR TITLE
Fix failing docs build

### DIFF
--- a/defmt-or-log/Cargo.toml
+++ b/defmt-or-log/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 repository = "https://github.com/t-moe/defmt-or-log"
 categories = ["embedded", "no-std"]
 
+[package.metadata.docs.rs]
+no-default-features = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
The at_least_one feature should be disabled when building docs.

The docs don't currently build
https://docs.rs/crate/defmt-or-log/latest

Closes #9 